### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -25,7 +25,7 @@ hasXLR8FloatAddSubMult	KEYWORD2
 hasXLR8FloatDiv	KEYWORD2
 hasXLR8Servo	KEYWORD2
 hasXLR8NeoPixel	KEYWORD2
-hasICSPVccGndSwap KEYWORD2
+hasICSPVccGndSwap	KEYWORD2
 enableInternalOscPin	KEYWORD2
 disableInternalOscPin	KEYWORD2
 


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords