### PR TITLE
Fix type issues in XLR8Info.cpp

### DIFF
--- a/src/XLR8Info.cpp
+++ b/src/XLR8Info.cpp
@@ -146,7 +146,7 @@ bool     XLR8Info::hasXLR8PID(void)         {return (XBEnables >> 4) & 1;}
 bool     XLR8Info::hasICSPVccGndSwap(void)  {
   // List of chip IDs from boards that have Vcc and Gnd swapped on the ICSP header
   //   Chip ID of affected parts are 0x????6E00. Store the ???? part
-  const static char cidTable[] PROGMEM =
+  const static unsigned int cidTable[] PROGMEM =
     {0xC88F,  0x08B7,  0xA877,  0xF437,
      0x94BF,  0x88D8,  0xB437,  0x94D7,  0x38BF,  0x145F,  0x288F,  0x28CF,
      0x543F,  0x0837,  0xA8B7,  0x748F,  0x8477,  0xACAF,  0x14A4,  0x0C50,

--- a/src/XLR8Info.cpp
+++ b/src/XLR8Info.cpp
@@ -157,7 +157,7 @@ bool     XLR8Info::hasICSPVccGndSwap(void)  {
      0x38BF};
   uint32_t chipId = getChipId();
   for (int i=0;i< sizeof(cidTable)/sizeof(cidTable[0]);i++) {
-    uint32_t cidtoTest = (cidTable[i] << 16) + 0x6E00;
+    uint32_t cidtoTest = ((uint32_t)cidTable[i] << 16) + 0x6E00;
     if (chipId == cidtoTest) {return true;}
   }
   return false;


### PR DESCRIPTION
This PR fixes two (related) type problems in `XLR8Info.cpp`.

- When defining the array of board IDs for which the ICSP Vcc and GND pins are swapped, the `char` type is used, but 16-bit hex literals are supplied. **This results in a compile error, rendering the code unusable without modification.**
    - This is resolved by changing the array type to `unsigned int`, to match the hex literals.
- When comparing the chip ID against the array defined above, a 16-bit left shift is applied to each element in that array. Even when the array's type is changed to `unsigned int`, the array element being shifted is only 16 bits long, so applying a 16-bit shift results in undefined behavior.
    - This is resolved by casting the array element to a 32-bit unsigned integer.

Resolves #2
